### PR TITLE
Fixed bower dependecy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
         "lib/postal.xframe.js"
     ],
     "dependencies": {
-        "lodash": "~2.4.1"
+        "lodash": "~2.4.1",
+        "postal.federation": ">=0.2.4",
     },
     "devDependencies": {
         "jquery": "~1.10.2",
@@ -30,7 +31,6 @@
         "requirejs": "~2.1.10",
         "postal.diagnostics": "~0.7.0",
         "postal.js": ">=0.8.11",
-        "postal.federation": ">=0.2.4",
         "riveter": "~0.1.2",
         "lodash": "~2.4.1"
     }


### PR DESCRIPTION
Postal.xframe depends on postal.federation when installing it via bower.

I've not moved postal.js from devDependencies to dependencies because postal.federation already has it as a bower dependency. 
