### PR TITLE
Don't use main field in bower.json for min version 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
         "url": "git://github.com/postaljs/postal.xframe.git"
     },
     "main": [
-        "lib/postal.xframe.min.js",
         "lib/postal.xframe.js"
     ],
     "dependencies": {


### PR DESCRIPTION
remove minified file from bower main.
See: https://github.com/postaljs/postal.js/pull/106