### PR TITLE
Remove bower paths from examples and spec files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,18 +19,15 @@
         "lib/postal.xframe.js"
     ],
     "dependencies": {
-        "lodash": "~2.4.1"
+        "lodash": "3.x"
     },
     "devDependencies": {
         "jquery": "~1.10.2",
         "bootstrap": "~3.0.3",
         "expect": "0.1.2",
         "mocha": "~1.17.0",
-        "requirejs": "~2.1.10",
         "postal.diagnostics": "~0.7.0",
         "postal.js": "~0.11.2",
-        "postal.federation": ">=0.4.0",
-        "riveter": "~0.1.2",
-        "lodash": "~2.4.1"
+        "postal.federation": ">=0.4.0"
     }
 }

--- a/example/iframe.html
+++ b/example/iframe.html
@@ -11,14 +11,13 @@
 	</div>
 	<div id="msgs"></div>
 
-	<script type="text/javascript" src="../bower/lodash/dist/lodash.js"></script>
-    <script type="text/javascript" src="../bower/jquery/jquery.js"></script>
-    <script type="text/javascript" src="../bower/postal.js/lib/postal.js"></script>
-    <script type="text/javascript" src="../bower/riveter/lib/riveter.js"></script>
-    <script type="text/javascript" src="../bower/postal.federation/lib/postal.federation.js"></script>
-    <script type="text/javascript" src="../bower/postal.request-response/lib/postal.request-response.js"></script>
-    <script type="text/javascript" src="../lib/postal.xframe.js"></script>
-    <script type="text/javascript">
+    <script src="../node_modules/lodash/index.js"></script>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/postal/lib/postal.js"></script>
+    <script src="../node_modules/postal.federation/lib/postal.federation.js"></script>
+    <script src="../node_modules/postal.request-response/lib/postal.request-response.js"></script>
+    <script src="../lib/postal.xframe.js"></script>
+    <script>
 	    // We need to tell postal how to get a deferred instance
 		postal.configuration.promise.createDeferred = function() {
 		    return new $.Deferred();

--- a/example/iframe2.html
+++ b/example/iframe2.html
@@ -10,14 +10,13 @@
 	    <input type="button" value="Disconnect" id="msg3">
 	</div>
 	<div id="msgs"></div>
-	<script type="text/javascript" src="../bower/lodash/dist/lodash.js"></script>
-    <script type="text/javascript" src="../bower/jquery/jquery.js"></script>
-    <script type="text/javascript" src="../bower/postal.js/lib/postal.js"></script>
-    <script type="text/javascript" src="../bower/riveter/lib/riveter.js"></script>
-    <script type="text/javascript" src="../bower/postal.federation/lib/postal.federation.js"></script>
-    <script type="text/javascript" src="../bower/postal.request-response/lib/postal.request-response.js"></script>
-    <script type="text/javascript" src="../lib/postal.xframe.js"></script>
-    <script type="text/javascript">
+    <script src="../node_modules/lodash/index.js"></script>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/postal/lib/postal.js"></script>
+    <script src="../node_modules/postal.federation/lib/postal.federation.js"></script>
+    <script src="../node_modules/postal.request-response/lib/postal.request-response.js"></script>
+    <script src="../lib/postal.xframe.js"></script>
+    <script>
     	// We need to tell postal how to get a deferred instance
 		postal.configuration.promise.createDeferred = function() {
 		    return new $.Deferred();

--- a/example/index.html
+++ b/example/index.html
@@ -3,14 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <title>Playground</title>
-    <script type="text/javascript" src="../bower/lodash/dist/lodash.js"></script>
-    <script type="text/javascript" src="../bower/jquery/jquery.js"></script>
-    <script type="text/javascript" src="../bower/postal.js/lib/postal.js"></script>
-    <script type="text/javascript" src="../bower/riveter/lib/riveter.js"></script>
-    <script type="text/javascript" src="../bower/postal.federation/lib/postal.federation.js"></script>
-    <script type="text/javascript" src="../bower/postal.request-response/lib/postal.request-response.js"></script>
-    <script type="text/javascript" src="../lib/postal.xframe.js"></script>
-    <script type="text/javascript" src="main.js"></script>
+    <script src="../node_modules/lodash/index.js"></script>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/postal/lib/postal.js"></script>
+    <script src="../node_modules/postal.federation/lib/postal.federation.js"></script>
+    <script src="../node_modules/postal.request-response/lib/postal.request-response.js"></script>
+    <script src="../lib/postal.xframe.js"></script>
+    <script src="main.js"></script>
 </head>
 <body>
 <div>

--- a/example/worker.js
+++ b/example/worker.js
@@ -4,7 +4,12 @@
             postMessage("WORKER1: " + JSON.stringify(msg, null, 2));
         }
     };
-    importScripts("../bower/lodash/dist/lodash.js", "../bower/riveter/lib/riveter.js", "../bower/postal.js/lib/postal.js", "../bower/postal.federation/lib/postal.federation.js", "../lib/postal.xframe.js");
+    importScripts(
+        "../node_modules/lodash/index.js", 
+        "../node_modules/postal/lib/postal.js", 
+        "../node_modules/postal.federation/lib/postal.federation.js", 
+        "../lib/postal.xframe.js"
+    );
     postal.instanceId("worker1");
     postal.fedx.configure({
         filterMode: "blacklist"

--- a/example/worker2.js
+++ b/example/worker2.js
@@ -4,7 +4,12 @@
             postMessage("WORKER2: " + JSON.stringify(msg, null, 2));
         }
     };
-    importScripts("../bower/lodash/dist/lodash.js", "../bower/riveter/lib/riveter.js", "../bower/postal.js/lib/postal.js", "../bower/postal.federation/lib/postal.federation.js", "../lib/postal.xframe.js");
+    importScripts(
+        "../node_modules/lodash/index.js", 
+        "../node_modules/postal/lib/postal.js", 
+        "../node_modules/postal.federation/lib/postal.federation.js", 
+        "../lib/postal.xframe.js"
+    );
     postal.instanceId("worker2");
     postal.fedx.addFilter([{
         channel: "webworker2",

--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html>
 <head>
     <title>postal.xframe</title>
-    <link rel="stylesheet" href="../bower/bootstrap/dist/css/bootstrap-theme.min.css" type="text/css">
-    <link rel="stylesheet" href="../bower/bootstrap/dist/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap-theme.min.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css" type="text/css">
     <style type="text/css">
         .banner {
             position: relative;
@@ -36,8 +36,8 @@
             margin-bottom: 20px;
         }
     </style>
-    <script type="text/javascript" src="../bower/jquery/jquery.js"></script>
-    <script type="text/javascript" src="../bower/bootstrap/dist/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="../node_modules/jquery/dist/jquery.js"></script>
+    <script type="text/javascript" src="../node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
 </head>
 <body>
     <header class="banner">

--- a/package.json
+++ b/package.json
@@ -1,85 +1,96 @@
 {
-    "name": "postal.xframe",
-    "description": "postal.js/postal.federation plugin for federating instances of postal.js across iframe/window boundaries.",
-    "version": "0.3.2",
-    "homepage": "http://github.com/postaljs/postal.xframe",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/postaljs/postal.xframe.git"
+  "name": "postal.xframe",
+  "description": "postal.js/postal.federation plugin for federating instances of postal.js across iframe/window boundaries.",
+  "version": "0.3.2",
+  "homepage": "http://github.com/postaljs/postal.xframe",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/postaljs/postal.xframe.git"
+  },
+  "author": "Jim Cowart (http://freshbrewedcode.com/jimcowart)",
+  "contributors": [
+    {
+      "name": "Jim Cowart",
+      "email": "jim@ifandelse.com",
+      "url": "http://freshbrewedcode.com/jimcowart"
     },
-    "author": "Jim Cowart (http://freshbrewedcode.com/jimcowart)",
-    "contributors": [{
-        "name": "Jim Cowart",
-        "email": "jim@ifandelse.com",
-        "url": "http://freshbrewedcode.com/jimcowart"
-    }, {
-        "name": "Jose Badeau",
-        "email": "jose.badeau@gmail.com",
-        "url": "https://github.com/jbadeau"
-    }, {
-        "name": "Ryan Rauh",
-        "email": "rauh.ryan@gmail.com",
-        "url": "http://rauhryan.github.com"
-    }, {
-        "name": "Dru Sellers",
-        "email": "dru@drusellers.com",
-        "url": "http://drusellers.com"
-    }, {
-        "name": "Robert Bar",
-        "email": "robert@rbsoftware.pl",
-        "url": "http://rbsoftware.pl"
-    }],
-    "keywords": [
-        "messaging",
-        "pubsub",
-        "frame",
-        "federation",
-        "postal"
-    ],
-    "bugs": {
-        "email": "jim@ifandelse.com",
-        "url": "http://github.com/postaljs/postal.xframe/issues"
+    {
+      "name": "Jose Badeau",
+      "email": "jose.badeau@gmail.com",
+      "url": "https://github.com/jbadeau"
     },
-    "directories": {
-        "lib": "lib"
+    {
+      "name": "Ryan Rauh",
+      "email": "rauh.ryan@gmail.com",
+      "url": "http://rauhryan.github.com"
     },
-    "main": "lib/postal.xframe.js",
-    "engines": {
-        "node": ">=0.4.0"
+    {
+      "name": "Dru Sellers",
+      "email": "dru@drusellers.com",
+      "url": "http://drusellers.com"
     },
-    "dependencies": {
-        "lodash": "~2.4.1",
-        "postal.federation": ">=0.4.0"
+    {
+      "name": "Robert Bar",
+      "email": "robert@rbsoftware.pl",
+      "url": "http://rbsoftware.pl"
+    }
+  ],
+  "keywords": [
+    "messaging",
+    "pubsub",
+    "frame",
+    "federation",
+    "postal"
+  ],
+  "bugs": {
+    "email": "jim@ifandelse.com",
+    "url": "http://github.com/postaljs/postal.xframe/issues"
+  },
+  "directories": {
+    "lib": "lib"
+  },
+  "main": "lib/postal.xframe.js",
+  "engines": {
+    "node": ">=0.4.0"
+  },
+  "dependencies": {
+    "lodash": "3.x",
+    "postal.federation": ">=0.4.0"
+  },
+  "devDependencies": {
+    "bootstrap": "^3.3.5",
+    "expect.js": "~0.2.0",
+    "express": "~3.4.7",
+    "gulp": "~3.8.10",
+    "gulp-beautify": "~1.0.3",
+    "gulp-header": "~1.0.2",
+    "gulp-hint-not": "~0.0.3",
+    "gulp-imports": "~0.0.1",
+    "gulp-plato": "~0.1.0",
+    "gulp-rename": "~0.2.1",
+    "gulp-uglify": "~0.1.0",
+    "gulp-util": "~2.2.9",
+    "jquery": "^2.1.4",
+    "mocha": "^2.3.0",
+    "open": "~0.0.4",
+    "postal.request-response": "^0.3.1"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://opensource.org/licenses/MIT"
     },
-    "devDependencies": {
-        "bower": "~1.2.8",
-        "gulp-util": "~2.2.9",
-        "gulp": "~3.8.10",
-        "gulp-imports": "~0.0.1",
-        "gulp-header": "~1.0.2",
-        "gulp-hint-not": "~0.0.3",
-        "gulp-uglify": "~0.1.0",
-        "gulp-rename": "~0.2.1",
-        "gulp-plato": "~0.1.0",
-        "gulp-beautify": "~1.0.3",
-        "express": "~3.4.7",
-        "open": "~0.0.4",
-        "expect.js": "~0.2.0",
-        "lodash": "~2.4.1"
-    },
-    "licenses": [{
-        "type": "MIT",
-        "url": "http://opensource.org/licenses/MIT"
-    }, {
-        "type": "GPL",
-        "url": "http://opensource.org/licenses/GPL-2.0"
-    }],
-    "scripts": {
-        "build": "gulp",
-        "start": "gulp server"
-    },
-    "files" : [
-        "LICENSE",
-        "lib"
-    ]
+    {
+      "type": "GPL",
+      "url": "http://opensource.org/licenses/GPL-2.0"
+    }
+  ],
+  "scripts": {
+    "build": "gulp",
+    "start": "gulp server"
+  },
+  "files": [
+    "LICENSE",
+    "lib"
+  ]
 }

--- a/spec/iframe.html
+++ b/spec/iframe.html
@@ -2,11 +2,10 @@
 <html>
 <head>
     <title></title>
-    <script src="../bower/lodash/dist/lodash.js"></script>
-    <script type="text/javascript" src="../bower/postal.js/lib/postal.js"></script>
-    <script type="text/javascript" src="../bower/riveter/lib/riveter.js"></script>
-    <script type="text/javascript" src="../bower/postal.federation/lib/postal.federation.js"></script>
-    <script type="text/javascript" src="../lib/postal.xframe.js"></script>
+    <script src="../node_modules/lodash/index.js"></script>
+    <script src="../node_modules/postal/lib/postal.js"></script>
+    <script src="../node_modules/postal.federation/lib/postal.federation.js"></script>
+    <script src="../lib/postal.xframe.js"></script>
     <script>
         postal.instanceId("testIframe");
         postal.fedx.addFilter([

--- a/spec/index.html
+++ b/spec/index.html
@@ -1,28 +1,27 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
 <head>
-    <link rel="stylesheet" href="../bower/mocha/mocha.css" />
+    <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
     <title>postal.xframe specs</title>
 </head>
 <body>
     <div id="mocha"></div>
     <iframe id="testIframe" src="iframe.html" style="overflow: hidden;visibility: hidden;" height="0" width="0" frameborder="0"></iframe>
-    <script src="../bower/jquery/jquery.js"></script>
-    <script src="../bower/lodash/dist/lodash.js"></script>
-    <script src="../bower/expect/expect.js"></script>
-    <script src="../bower/mocha/mocha.js"></script>
-    <script type="text/javascript">
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../node_modules/lodash/index.js"></script>
+    <script src="../node_modules/expect.js/expect.js"></script>
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script>
         mocha.setup({ ui: 'bdd', timeout: 60000, ignoreLeaks: true });
         if (!window.location.origin) {
             window.location.origin = window.location.protocol + "//" + window.location.host;
         }
     </script>
-    <script type="text/javascript" src="../bower/postal.js/lib/postal.js"></script>
-    <script type="text/javascript" src="../bower/riveter/lib/riveter.js"></script>
-    <script type="text/javascript" src="../bower/postal.federation/lib/postal.federation.js"></script>
-    <script type="text/javascript" src="../lib/postal.xframe.js"></script>
-    <script type="text/javascript" src="xframe.units.spec.js"></script>
-    <script type="text/javascript">
+    <script src="../node_modules/postal/lib/postal.js"></script>
+    <script src="../node_modules/postal.federation/lib/postal.federation.js"></script>
+    <script src="../lib/postal.xframe.js"></script>
+    <script src="xframe.units.spec.js"></script>
+    <script>
         postal.instanceId("test123");
         mocha.run();
     </script>


### PR DESCRIPTION
Now, only `npm install` is needed before running `npm start`. This also removes the now unnecessary riveter dependency.