### PR TITLE
Add postal devDependency, npm test script, and correct XFrameClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,9 @@
     "postal.federation": ">=0.5.2"
   },
   "devDependencies": {
-  	"babel": "5.x",
+    "babel": "5.x",
     "babel-loader": "~4.0.0",
+    "bootstrap": "^3.3.5",
     "eslint": "^1.3.1",
     "expect.js": "~0.2.0",
     "express": "~3.4.7",
@@ -88,15 +89,16 @@
     "karma-spec-reporter": "0.0.20",
     "mocha": "^2.3.0",
     "open": "~0.0.4",
+    "postal": "^2.0.4",
+    "postal.request-response": "^0.3.1",
     "webpack": "^1.12.1",
-    "webpack-stream": "^2.1.0",
-    "bootstrap": "^3.3.5",
-    "postal.request-response": "^0.3.1"
+    "webpack-stream": "^2.1.0"
   },
   "license": "(MIT OR GPL-2.0)",
   "scripts": {
     "build": "gulp",
-    "start": "gulp server"
+    "start": "gulp server",
+    "test": "gulp test"
   },
   "files": [
     "LICENSE",

--- a/src/XFrameClient.js
+++ b/src/XFrameClient.js
@@ -5,8 +5,8 @@ import { state, env } from "./state";
 export default class XFrameClient extends postal.fedx.FederationClient {
 
 	constructor( ...args ) {
-		this.transportName = "xframe";
 		super( ...args );
+		this.transportName = "xframe";
 	}
 
 	shouldProcess() {


### PR DESCRIPTION
`postal` was missing as a devDependency, which caused the gulp tests to fail. I'm also adding a standard NPM test script that executes the gulp tests. 

The XFrameClient class was blowing up Babel because it was setting `this.transportName = "xframe"` prior to invoking `super`. 

NPM reordered the libs alphabetically; the only change is adding postal.